### PR TITLE
修复未清除的换行符导致的语句丢失

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -112,7 +112,7 @@ std::unique_ptr<BlockStmt> Parser::parse(const std::vector<Token>& tokens) {
 
     // ========== 全局块解析：直到 EOF ==========
     while (curr_token().type != TokenType::EndOfFile) {
-        if (curr_token().type == TokenType::EndOfLine)
+        while(curr_token().type == TokenType::EndOfLine)
         {
             skip_end_of_ln();
         }


### PR DESCRIPTION
对于
```
a=0
b=6
fn x()
    print(4)
end

x()
```
时在执行完函数的定义后未清除多余的换行符导致 EndOfLine 进入`Parser::parse_stmt` 并给出了无效的结果，在 259-262 行
```c++
// 跳过无效Token（容错处理）
while (curr_tok_idx_ < tokens_.size() && curr_token().type != TokenType::EndOfLine) {
    skip_token();  // 跳过当前无效Token
}
```

将 `Identifier 'x'` 跳过并导致运行结果和预期不符