### PR TITLE
Fix my mistake in PR #17: use script directory instead of simply absolute()

### DIFF
--- a/libs/builtins/builtin_functions.cpp
+++ b/libs/builtins/builtin_functions.cpp
@@ -378,7 +378,7 @@ model::Object* open(model::Object* self, const model::List* args) {
     auto path = cast_to_str(args->val[0])->val;
     auto mode = cast_to_str(args->val[1])->val;
 
-    auto real_path = std::filesystem::absolute(path);
+    auto real_path = std::filesystem::absolute(kiz::Vm::get_current_file_path().parent_path() / path);
 
     std::ios_base::openmode open_mode = std::ios_base::in | std::ios_base::out; // 默认不设置 binary
     // 根据 mode 设置具体标志（此处 mode 不包含 'b'，即默认文本模式）

--- a/src/vm/handle_import.cpp
+++ b/src/vm/handle_import.cpp
@@ -144,7 +144,7 @@ void Vm::handle_import(const std::string& module_path) {
     bool file_in_path = false;
     fs::path actually_found_path = "";
     std::vector for_search_paths = {
-        fs::absolute(module_path),
+        fs::absolute(current_file_path.parent_path() / module_path),
         get_exe_abs_dir() / fs::path(module_path),
         get_exe_abs_dir().parent_path() / fs::path("modules") / fs::path(module_path) / fs::path("__main__.kiz"),
         get_exe_abs_dir().parent_path() / fs::path("modules") / fs::path(module_path)


### PR DESCRIPTION
In #17, i incorrectly used `std::filesystem::absolute()` to resolve module paths. This fails when the current working directory is not the script’s directory, as shown below:
```
$ ./kiz examples/import_test.kiz

Trace Back: 

File "examples/import_test.kiz"
1 | import test at "be_imported.kiz"
    ^^^^^^
PathError : Failed to find module in path 'be_imported.kiz', tried '/home/iamzhz/Code/kizi/be_imported.kiz', '/home/iamzhz/Code/kizi/be_imported.kiz', '/home/iamzhz/Code/modules/be_imported.kiz/__main__.kiz', '/home/iamzhz/Code/modules/be_imported.kiz'
```
This PR fixes it by using `kiz::Vm::get_current_file_path().parent_path()` as the base for relative paths, which correctly points to the directory of the running .kiz file.

Thank you.